### PR TITLE
Handle crashing error when client disconnects

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -50,4 +50,7 @@ wss.on('connection', (ws) => {
       users
     }, ws)
   })
+  
+  ws.on('error', () => {});
+  
 })


### PR DESCRIPTION
A listener for the 'error' event is now required in ws to avoid causing a crash when some clients (especially Chrome) disconnect. See this ws issue:  https://github.com/websockets/ws/issues/1256.